### PR TITLE
Use type RouteValueDictionary when creating links with querystrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ public class Filter
 
 The code above will produce an API response in JSON format like the example below when the _GetPerson_ route is invoked.
 
-````json
+```json
 {
   "name": "Juan Dela Cruz",
   "_links": {
@@ -369,6 +369,7 @@ The code above will produce an API response in JSON format like the example belo
     }
   }
 }
+```
 
 ### External
 
@@ -379,7 +380,7 @@ hypermediaService
   .AddSelf(model)
   .AddLink("profile", "https://social-media.example.com/api/profile/1", "GET"))
   .Document;
-````
+```
 
 A condition can also be passed to `AddLink()`.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ public class PersonController
 }
 ```
 
-The code above will produce an API response in JSON format like the example below.
+The code above will produce an API response in JSON format like the example below when the _GetPerson_ route is invoked.
 
 ```json
 {
@@ -103,6 +103,18 @@ The code above will produce an API response in JSON format like the example belo
 ```
 
 ## Adding links
+
+### Self
+
+A _self_ link can be added by calling the `AddSelf()` method. This feature is part of [iHeartLinks.Core](https://github.com/ponki-d-monkey/iHeartLinks.Core).
+
+```csharp
+hypermediaService
+  .AddSelf(model)
+  .Document;
+```
+
+Take note, querystrings will be included in the _self_ link _href_ automatically if querystrings have been passed in the original request.
 
 ### Conditional
 
@@ -227,7 +239,7 @@ Some features can be found in the `iHeartLinks.AspNetCore.Extensions` namespace.
 
 ### Templated
 
-Templated links can be added to a model by calling the method `AddRouteTemplate()` method.
+Templated links can be added to a model by calling the `AddRouteTemplate()` method.
 
 ```csharp
 using iHeartLinks.AspNetCore;
@@ -266,7 +278,7 @@ public class PersonController
 }
 ```
 
-The code above will produce an API response in JSON format like the example below.
+The code above will produce an API response in JSON format like the example below when the _GetPeople_ route is invoked.
 
 ```json
 {
@@ -287,6 +299,77 @@ The code above will produce an API response in JSON format like the example belo
 
 Take note, calling the `AddRouteTemplate()` method without enabling _templated links_ may result in an exception.
 
+A querystring template will be included automatically if the controller action accepts a parameter as a query parameter.
+
+```csharp
+using iHeartLinks.AspNetCore;
+using iHeartLinks.AspNetCore.Extensions;
+using iHeartLinks.Core;
+
+[Route("api/[controller]")]
+[ApiController]
+public class PersonController
+{
+  private readonly IHypermediaService hypermediaService;
+
+  public PersonController(IHypermediaService hypermediaService)
+  {
+    this.hypermediaService = hypermediaService;
+  }
+
+  [HttpGet]
+  [Route("", Name = "GetPeople")]
+  public IActionResult Get([FromQuery] Filter filter)
+  {
+    throw new NotImplementedException();
+  }
+
+  [HttpGet]
+  [Route("{id}", Name = "GetPerson")]
+  public IActionResult Get(long id)
+  {
+    var model = new Person
+    {
+      Name = "Juan Dela Cruz"
+    };
+
+    return Ok(hypermediaService
+      .AddSelf(model)
+      .AddRouteTemplate("filter", "GetPeople")
+      .Document);
+  }
+}
+```
+
+`Filter` is an object with the following properties.
+
+```csharp
+public class Filter
+{
+  public string Search { get; set; }
+  public int PageNumber { get; set; }
+  public int PageSize { get; set; }
+}
+```
+
+The code above will produce an API response in JSON format like the example below when the _GetPerson_ route is invoked.
+
+````json
+{
+  "name": "Juan Dela Cruz",
+  "_links": {
+    "self": {
+      "href": "https://your.api.com/person/1",
+      "method": "GET"
+    },
+    "filter": {
+      "href": "https://your.api.com/person{?Search,PageNumber,PageSize}",
+      "method": "GET",
+      "templated": true
+    }
+  }
+}
+
 ### External
 
 To add an external link with an _HTTP method_, use the `AddLink()` method in the `iHeartLinks.AspNetCore.Extensions` namespace.
@@ -296,7 +379,7 @@ hypermediaService
   .AddSelf(model)
   .AddLink("profile", "https://social-media.example.com/api/profile/1", "GET"))
   .Document;
-```
+````
 
 A condition can also be passed to `AddLink()`.
 

--- a/src/iHeartLinks.AspNetCore/HypermediaService.cs
+++ b/src/iHeartLinks.AspNetCore/HypermediaService.cs
@@ -6,7 +6,9 @@ using iHeartLinks.AspNetCore.Enrichers;
 using iHeartLinks.AspNetCore.LinkFactories;
 using iHeartLinks.AspNetCore.UrlPathProviders;
 using iHeartLinks.Core;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 
 namespace iHeartLinks.AspNetCore
 {
@@ -42,7 +44,7 @@ namespace iHeartLinks.AspNetCore
         {
             return DoGetLink(LinkRequestBuilder
                 .CreateWithRouteName(urlHelper.Value.ActionContext.ActionDescriptor.AttributeRouteInfo.Name)
-                .SetRouteValuesIfNotNull(urlHelper.Value.ActionContext.HttpContext.Request.Query?.ToDictionary(x => x.Key, x => x.Value.ToString())));
+                .SetRouteValuesIfNotNull(ConvertToRouteValues(urlHelper.Value.ActionContext.HttpContext.Request.Query)));
         }
 
         public Link GetLink(LinkRequest request)
@@ -63,6 +65,16 @@ namespace iHeartLinks.AspNetCore
             }
 
             return DoGetLink(request);
+        }
+
+        private RouteValueDictionary ConvertToRouteValues(IQueryCollection query)
+        {
+            if (query == null)
+            {
+                return null;
+            }
+
+            return RouteValueDictionary.FromArray(query.ToDictionary(x => x.Key, x => x.Value as object).ToArray());
         }
 
         private Link DoGetLink(LinkRequest request)

--- a/tests/iHeartLinks.AspNetCore.Tests/HypermediaServiceTests.cs
+++ b/tests/iHeartLinks.AspNetCore.Tests/HypermediaServiceTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using Xunit;
@@ -179,7 +180,7 @@ namespace iHeartLinks.AspNetCore.Tests
             mockUrlPathProvider.Verify(x => x.Provide(It.Is<LinkRequest>(x =>
                 x.GetRouteName() == TestRouteName &&
                 x.GetRouteValues() != null &&
-                x.GetRouteValues() is Dictionary<string, string>)),
+                x.GetRouteValues() is RouteValueDictionary)),
             Times.Once);
         }
 
@@ -204,17 +205,17 @@ namespace iHeartLinks.AspNetCore.Tests
 
             SetupUrlHelperBuilder(mockHttpContext.Object);
 
-            var expectedQuery = default(Dictionary<string, string>);
+            var expectedQuery = default(RouteValueDictionary);
             mockUrlPathProvider
-                .Setup(x => x.Provide(It.Is<LinkRequest>(x => x.GetRouteName() == TestRouteName && x.GetRouteValues() is Dictionary<string, string>)))
+                .Setup(x => x.Provide(It.Is<LinkRequest>(x => x.GetRouteName() == TestRouteName && x.GetRouteValues() is RouteValueDictionary)))
                 .Returns(new Uri(TestRouteUrl, UriKind.RelativeOrAbsolute))
-                .Callback<LinkRequest>(x => expectedQuery = x.GetRouteValues() as Dictionary<string, string>);
+                .Callback<LinkRequest>(x => expectedQuery = x.GetRouteValues() as RouteValueDictionary);
 
             sut.GetLink();
 
             expectedQuery.Should().NotBeNull();
-            expectedQuery.Should().Contain("q1", "v1");
-            expectedQuery.Should().Contain("q2", "v2.1,v2.2");
+            expectedQuery.Should().Contain("q1", new StringValues("v1"));
+            expectedQuery.Should().Contain("q2", new StringValues(new[] { "v2.1", "v2.2" }));
         }
 
         [Fact]


### PR DESCRIPTION
Use type RouteValueDictionary instead of Dictionary<string, string> to generate querystrings with array values properly